### PR TITLE
Centralize Terragrunt configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-openmetadata-ecs-aurora-assets
 
-This repository provides Terraform modules to deploy an ECS-based OpenMetadata service with an Aurora database. Terragrunt configurations are available under `infra/terragrunt` for the `aws`, `backend`, and `cicd` environments, enabling remote state management and easier orchestration. Please note the following when using this module:
+This repository provides Terraform modules to deploy an ECS-based OpenMetadata service with an Aurora database. Terragrunt configuration is centralized with `infra/terragrunt/terragrunt.hcl`, and the environment directories (`aws`, `backend`, `cicd`) simply include this root file for remote state and provider settings. Please note the following when using this module:
 
 ## Key Notes
 

--- a/infra/terragrunt/environment/dev/aws/terragrunt.hcl
+++ b/infra/terragrunt/environment/dev/aws/terragrunt.hcl
@@ -1,43 +1,9 @@
+include {
+  path = find_in_parent_folders()
+}
+
 terraform {
   # Include the entire Terraform directory so relative module
   # paths work correctly when Terragrunt copies the code.
   source = "../../../../..//infra/terraform/environment/dev/aws"
-}
-
-remote_state {
-  backend = "s3"
-  config = {
-    bucket = "ethan-s3-apne1-tfstate"
-    key    = "ethan/dev/aws/remote.tfstate"
-    region = "ap-northeast-1"
-    encrypt = true
-  }
-}
-
-generate "provider" {
-  path = "generated_provider.tf"
-  if_exists = "overwrite"
-  contents = <<EOT
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 6.0.0"
-    }
-    http = {
-      source  = "hashicorp/http"
-      version = "~> 3.5.0"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.7.2"
-    }
-  }
-  required_version = "~> 1.12.2"
-}
-
-provider "aws" {}
-provider "http" {}
-provider "random" {}
-EOT
 }

--- a/infra/terragrunt/environment/dev/backend/terragrunt.hcl
+++ b/infra/terragrunt/environment/dev/backend/terragrunt.hcl
@@ -1,41 +1,7 @@
+include {
+  path = find_in_parent_folders()
+}
+
 terraform {
   source = "../../../../..//infra/terraform/environment/dev/backend"
-}
-
-remote_state {
-  backend = "s3"
-  config = {
-    bucket = "ethan-s3-apne1-tfstate"
-    key    = "ethan/dev/backend/remote.tfstate"
-    region = "ap-northeast-1"
-    encrypt = true
-  }
-}
-
-generate "provider" {
-  path = "generated_provider.tf"
-  if_exists = "overwrite"
-  contents = <<EOT
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 6.0.0"
-    }
-    http = {
-      source  = "hashicorp/http"
-      version = "~> 3.5.0"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.7.2"
-    }
-  }
-  required_version = "~> 1.12.2"
-}
-
-provider "aws" {}
-provider "http" {}
-provider "random" {}
-EOT
 }

--- a/infra/terragrunt/environment/dev/cicd/terragrunt.hcl
+++ b/infra/terragrunt/environment/dev/cicd/terragrunt.hcl
@@ -1,41 +1,7 @@
+include {
+  path = find_in_parent_folders()
+}
+
 terraform {
   source = "../../../../..//infra/terraform/environment/dev/cicd"
-}
-
-remote_state {
-  backend = "s3"
-  config = {
-    bucket = "ethan-s3-apne1-tfstate"
-    key    = "ethan/dev/cicd/remote.tfstate"
-    region = "ap-northeast-1"
-    encrypt = true
-  }
-}
-
-generate "provider" {
-  path = "generated_provider.tf"
-  if_exists = "overwrite"
-  contents = <<EOT
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 6.0.0"
-    }
-    http = {
-      source  = "hashicorp/http"
-      version = "~> 3.5.0"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.7.2"
-    }
-  }
-  required_version = "~> 1.12.2"
-}
-
-provider "aws" {}
-provider "http" {}
-provider "random" {}
-EOT
 }

--- a/infra/terragrunt/terragrunt.hcl
+++ b/infra/terragrunt/terragrunt.hcl
@@ -1,0 +1,42 @@
+locals {
+  state_bucket = "ethan-s3-apne1-tfstate"
+  aws_region   = "ap-northeast-1"
+}
+
+remote_state {
+  backend = "s3"
+  config = {
+    bucket  = local.state_bucket
+    key     = "ethan/${replace(path_relative_to_include(), \"environment/\", \"\")}/remote.tfstate"
+    region  = local.aws_region
+    encrypt = true
+  }
+}
+
+generate "provider" {
+  path      = "generated_provider.tf"
+  if_exists = "overwrite"
+  contents  = <<EOT
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0.0"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 3.5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.7.2"
+    }
+  }
+  required_version = "~> 1.12.2"
+}
+
+provider "aws" {}
+provider "http" {}
+provider "random" {}
+EOT
+}


### PR DESCRIPTION
## Summary
- centralize Terragrunt setup under `infra/terragrunt/terragrunt.hcl`
- include this root file from each environment
- update README for the new structure

## Testing
- `terraform fmt -recursive infra/terragrunt`
- `terraform fmt -recursive infra/terraform`

------
https://chatgpt.com/codex/tasks/task_b_685c03977c2c83249df22edf09ce0f82