### PR TITLE
Refactor env vars into terragrunt locals

### DIFF
--- a/infra/terraform/aws/main.tf
+++ b/infra/terraform/aws/main.tf
@@ -1,0 +1,117 @@
+module "iam_github_oidc" {
+  source            = "../module/aws/iam_github_oidc"
+  name_prefix       = "${var.pj_name}-${var.env}"
+  region_short_name = var.region_short_name
+  repo_full_name    = var.repo_full_name
+}
+
+module "network" {
+  source               = "../module/aws/network"
+  name_prefix          = "${var.pj_name}-${var.env}"
+  region               = var.region
+  region_short_name    = var.region_short_name
+  az_a_name            = var.az_a_name
+  az_c_name            = var.az_c_name
+  cidr_vpc             = var.cidr_vpc
+  cidr_subnets_public  = var.cidr_subnets_public
+  cidr_subnets_private = var.cidr_subnets_private
+}
+
+module "openmetadata_kms_key" {
+  source            = "../module/aws/openmetadata/kms_key"
+  name_prefix       = "${var.pj_name}-${var.env}"
+  region_short_name = var.region_short_name
+}
+
+module "openmetadata_s3" {
+  source                 = "../module/aws/openmetadata/s3"
+  name_prefix            = "${var.pj_name}-${var.env}"
+  region_short_name      = var.region_short_name
+  allowed_ip_list        = var.allowed_ip_list
+  s3_gateway_endpoint_id = module.network.s3_gateway_endpoint_id
+  s3_kms_key_arn         = module.openmetadata_kms_key.s3_kms_key_arn
+}
+
+module "openmetadata_iam" {
+  source                    = "../module/aws/openmetadata/iam"
+  name_prefix               = "${var.pj_name}-${var.env}"
+  region_short_name         = var.region_short_name
+  docker_envfile_bucket_arn = module.openmetadata_s3.docker_envfile_bucket_arn
+}
+
+module "openmetadata_security_group" {
+  source            = "../module/aws/openmetadata/security_group"
+  name_prefix       = "${var.pj_name}-${var.env}"
+  region_short_name = var.region_short_name
+  allowed_ip_list   = var.allowed_ip_list
+  vpc_id            = module.network.vpc_id
+}
+
+module "openmetadata_secretmanager" {
+  source            = "../module/aws/openmetadata/secrets_manager"
+  name_prefix       = "${var.pj_name}-${var.env}"
+  region_short_name = var.region_short_name
+}
+
+module "openmetadata_cloudwatch" {
+  source                = "../module/aws/openmetadata/cloudwatch"
+  log_retention_in_days = var.log_retention_in_days
+}
+
+module "openmetadata_aurora" {
+  source                   = "../module/aws/openmetadata/aurora"
+  name_prefix              = "${var.pj_name}-${var.env}"
+  region_short_name        = var.region_short_name
+  subnet_a_private_id      = module.network.subnet_a_private_id
+  subnet_c_private_id      = module.network.subnet_c_private_id
+  aurora_kms_key_arn       = module.openmetadata_kms_key.aurora_kms_key_arn
+  aurora_security_group_id = module.openmetadata_security_group.openmetaedata_aurora_security_group_id
+  aurora_secret_name       = module.openmetadata_secretmanager.aurora_secret_name
+}
+
+module "openmetadata_ecr" {
+  source            = "../module/aws/openmetadata/ecr"
+  allowed_ip_list   = var.allowed_ip_list
+  vpc_id            = module.network.vpc_id
+  ecr_kms_key_arn   = module.openmetadata_kms_key.ecr_kms_key_arn
+  repository_list   = var.repository_list
+  elasticsearch_tag = var.elasticsearch_tag
+  openmetadata_tag  = var.openmetadata_tag
+  ingestion_tag     = var.ingestion_tag
+}
+
+module "openmetadata_lb" {
+  source                            = "../module/aws/openmetadata/load_balancer"
+  domain_name                       = var.domain_name
+  name_prefix                       = "${var.pj_name}-${var.env}"
+  region_short_name                 = var.region_short_name
+  vpc_id                            = module.network.vpc_id
+  subnet_a_public_id                = module.network.subnet_a_public_id
+  subnet_c_public_id                = module.network.subnet_c_public_id
+  openmetadata_lb_security_group_id = module.openmetadata_security_group.openmetadata_lb_security_group_id
+}
+
+module "openmetadata_ecs" {
+  source                              = "../module/aws/openmetadata/ecs"
+  region                              = var.region
+  region_short_name                   = var.region_short_name
+  name_prefix                         = "${var.pj_name}-${var.env}"
+  subnet_a_private_id                 = module.network.subnet_a_private_id
+  subnet_c_private_id                 = module.network.subnet_c_private_id
+  domain_name                         = var.domain_name
+  elasticsearch_tag                   = var.elasticsearch_tag
+  openmetadata_tag                    = var.openmetadata_tag
+  ingestion_tag                       = var.ingestion_tag
+  ecs_task_role_arn                   = module.openmetadata_iam.ecs_task_role_arn
+  ecs_task_execution_role_arn         = module.openmetadata_iam.ecs_task_execution_role_arn
+  openmetadata_secret_name            = module.openmetadata_secretmanager.openmetadata_secret_name
+  aurora_cluster_endpoint             = module.openmetadata_aurora.aurora_cluster_endpoint
+  docker_envfile_bucket_arn           = module.openmetadata_s3.docker_envfile_bucket_arn
+  elastic_search_log_group_name       = module.openmetadata_cloudwatch.elastic_search_log_group_name
+  migrate_all_log_group_name          = module.openmetadata_cloudwatch.migrate_all_log_group_name
+  openmetadata_server_log_group_name  = module.openmetadata_cloudwatch.openmetadata_server_log_group_name
+  openmetadata_airflow_log_group_name = module.openmetadata_cloudwatch.openmetadata_airflow_log_group_name
+  openmetadata_ecs_security_group_id  = module.openmetadata_security_group.openmetadata_ecs_security_group_id
+  openmetadata_target_group_arn       = module.openmetadata_lb.openmetadata_target_group_arn
+  ecr_depends_on                      = module.openmetadata_ecr.ecr_depends_on
+}

--- a/infra/terraform/aws/variables.tf
+++ b/infra/terraform/aws/variables.tf
@@ -1,0 +1,84 @@
+variable "pj_name" {
+  type        = string
+  description = "Project name prefix"
+}
+
+variable "env" {
+  type        = string
+  description = "Environment name"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region"
+}
+
+variable "region_short_name" {
+  type        = string
+  description = "Short name for region"
+}
+
+variable "repo_full_name" {
+  type        = string
+  description = "GitHub repository full name"
+}
+
+variable "allowed_ip_list" {
+  type        = list(string)
+  description = "Allowed IP ranges"
+}
+
+variable "cidr_vpc" {
+  type        = string
+  description = "CIDR block for VPC"
+}
+
+variable "cidr_subnets_public" {
+  type        = list(string)
+  description = "CIDR blocks for public subnets"
+}
+
+variable "cidr_subnets_private" {
+  type        = list(string)
+  description = "CIDR blocks for private subnets"
+}
+
+variable "az_a_name" {
+  type        = string
+  description = "Availability zone A name"
+}
+
+variable "az_c_name" {
+  type        = string
+  description = "Availability zone C name"
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Domain name for load balancer"
+}
+
+variable "repository_list" {
+  type        = list(string)
+  description = "ECR repository names"
+}
+
+variable "elasticsearch_tag" {
+  type        = string
+  description = "Elasticsearch image tag"
+}
+
+variable "openmetadata_tag" {
+  type        = string
+  description = "OpenMetadata image tag"
+}
+
+variable "ingestion_tag" {
+  type        = string
+  description = "Ingestion image tag"
+}
+
+variable "log_retention_in_days" {
+  type        = number
+  description = "CloudWatch log retention"
+}

--- a/infra/terraform/backend/main.tf
+++ b/infra/terraform/backend/main.tf
@@ -1,0 +1,8 @@
+module "backend" {
+  source                     = "../module/backend"
+  name_prefix                = "${var.pj_name}-${var.env}"
+  region_short_name          = var.region_short_name
+  allowed_ip_list            = var.allowed_ip_list
+  github_actions_iam_role_id = var.github_actions_iam_role_id
+  allowed_vpce_ids           = var.allowed_vpce_ids
+}

--- a/infra/terraform/backend/variables.tf
+++ b/infra/terraform/backend/variables.tf
@@ -1,0 +1,29 @@
+variable "pj_name" {
+  type        = string
+  description = "Project name prefix"
+}
+
+variable "env" {
+  type        = string
+  description = "Environment name"
+}
+
+variable "region_short_name" {
+  type        = string
+  description = "Short name for region"
+}
+
+variable "allowed_ip_list" {
+  type        = list(string)
+  description = "Allowed IP ranges"
+}
+
+variable "github_actions_iam_role_id" {
+  type        = list(string)
+  description = "GitHub Actions IAM role IDs"
+}
+
+variable "allowed_vpce_ids" {
+  type        = list(string)
+  description = "Allowed VPC endpoint IDs"
+}

--- a/infra/terraform/cicd/main.tf
+++ b/infra/terraform/cicd/main.tf
@@ -1,0 +1,6 @@
+module "iam_github_oidc" {
+  source            = "../module/aws/iam_github_oidc"
+  name_prefix       = "${var.pj_name}-${var.env}"
+  region_short_name = var.region_short_name
+  repo_full_name    = var.repo_full_name
+}

--- a/infra/terraform/cicd/variables.tf
+++ b/infra/terraform/cicd/variables.tf
@@ -1,0 +1,19 @@
+variable "pj_name" {
+  type        = string
+  description = "Project name prefix"
+}
+
+variable "env" {
+  type        = string
+  description = "Environment name"
+}
+
+variable "region_short_name" {
+  type        = string
+  description = "Short name for region"
+}
+
+variable "repo_full_name" {
+  type        = string
+  description = "GitHub repository full name"
+}

--- a/infra/terragrunt/environment/dev/aws/terragrunt.hcl
+++ b/infra/terragrunt/environment/dev/aws/terragrunt.hcl
@@ -3,7 +3,48 @@ include {
 }
 
 terraform {
-  # Include the entire Terraform directory so relative module
-  # paths work correctly when Terragrunt copies the code.
-  source = "../../../../..//infra/terraform/environment/dev/aws"
+  source = "../../../terraform/aws"
+}
+
+locals {
+  pj_name           = "ethan"
+  env               = "dev"
+  region            = "ap-northeast-1"
+  region_short_name = "apne1"
+  repo_full_name    = "kuma0128/terraform-openmetadata-ecs-aurora-assets"
+
+  allowed_ip_list = ["" ]
+
+  cidr_vpc             = ""
+  cidr_subnets_public  = ["", ""]
+  cidr_subnets_private = ["", ""]
+  az_a_name            = "ap-northeast-1a"
+  az_c_name            = "ap-northeast-1c"
+
+  domain_name            = ""
+  repository_list        = ["elasticsearch", "openmetadata/server", "openmetadata/ingestion"]
+  elasticsearch_tag      = "8.10.2"
+  openmetadata_tag       = "1.5.3"
+  ingestion_tag          = "1.5.3"
+  log_retention_in_days  = 30
+}
+
+inputs = {
+  pj_name              = local.pj_name
+  env                  = local.env
+  region               = local.region
+  region_short_name    = local.region_short_name
+  repo_full_name       = local.repo_full_name
+  allowed_ip_list      = local.allowed_ip_list
+  cidr_vpc             = local.cidr_vpc
+  cidr_subnets_public  = local.cidr_subnets_public
+  cidr_subnets_private = local.cidr_subnets_private
+  az_a_name            = local.az_a_name
+  az_c_name            = local.az_c_name
+  domain_name          = local.domain_name
+  repository_list      = local.repository_list
+  elasticsearch_tag    = local.elasticsearch_tag
+  openmetadata_tag     = local.openmetadata_tag
+  ingestion_tag        = local.ingestion_tag
+  log_retention_in_days = local.log_retention_in_days
 }

--- a/infra/terragrunt/environment/dev/backend/terragrunt.hcl
+++ b/infra/terragrunt/environment/dev/backend/terragrunt.hcl
@@ -3,5 +3,23 @@ include {
 }
 
 terraform {
-  source = "../../../../..//infra/terraform/environment/dev/backend"
+  source = "../../../terraform/backend"
+}
+
+locals {
+  pj_name              = "ethan"
+  env                  = "dev"
+  region_short_name    = "apne1"
+  allowed_ip_list      = ["" ]
+  github_actions_iam_role_id = []
+  allowed_vpce_ids          = []
+}
+
+inputs = {
+  pj_name                = local.pj_name
+  env                    = local.env
+  region_short_name      = local.region_short_name
+  allowed_ip_list        = local.allowed_ip_list
+  github_actions_iam_role_id = local.github_actions_iam_role_id
+  allowed_vpce_ids       = local.allowed_vpce_ids
 }

--- a/infra/terragrunt/environment/dev/cicd/terragrunt.hcl
+++ b/infra/terragrunt/environment/dev/cicd/terragrunt.hcl
@@ -3,5 +3,19 @@ include {
 }
 
 terraform {
-  source = "../../../../..//infra/terraform/environment/dev/cicd"
+  source = "../../../terraform/cicd"
+}
+
+locals {
+  pj_name           = "ethan"
+  env               = "dev"
+  region_short_name = "apne1"
+  repo_full_name    = "kuma0128/terraform-openmetadata-ecs-aurora-assets"
+}
+
+inputs = {
+  pj_name           = local.pj_name
+  env               = local.env
+  region_short_name = local.region_short_name
+  repo_full_name    = local.repo_full_name
 }


### PR DESCRIPTION
## Summary
- introduce generic Terraform roots for `aws`, `backend`, and `cicd`
- move environment specific settings into each environment's `terragrunt.hcl`

## Testing
- `terraform fmt -recursive`
- `tflint --recursive` on Terraform directories

------
https://chatgpt.com/codex/tasks/task_b_685c0cd4480c8324aca772d69ca2137c