### PR TITLE
Add terragrunt dependencies

### DIFF
--- a/infra/terragrunt/environment/dev/aws/terragrunt.hcl
+++ b/infra/terragrunt/environment/dev/aws/terragrunt.hcl
@@ -6,6 +6,10 @@ terraform {
   source = "../../../terraform/aws"
 }
 
+dependencies {
+  paths = ["../backend"]
+}
+
 locals {
   pj_name           = "ethan"
   env               = "dev"

--- a/infra/terragrunt/environment/dev/backend/terragrunt.hcl
+++ b/infra/terragrunt/environment/dev/backend/terragrunt.hcl
@@ -6,6 +6,10 @@ terraform {
   source = "../../../terraform/backend"
 }
 
+dependencies {
+  paths = ["../cicd"]
+}
+
 locals {
   pj_name              = "ethan"
   env                  = "dev"


### PR DESCRIPTION
## Summary
- ensure terragrunt modules run sequentially
- `backend` now depends on `cicd`
- `aws` now depends on `backend`

## Testing
- `terraform fmt -check -recursive infra`
- ❌ `tflint` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685cdee7c79c8324aff2b53cb5334077