### PR TITLE
Remove role-chaining from workflows

### DIFF
--- a/.github/workflows/terragrunt-apply.yml
+++ b/.github/workflows/terragrunt-apply.yml
@@ -45,7 +45,6 @@ jobs:
         with:
           aws-region: ${{ env.aws_default_region }}
           role-to-assume: ${{ secrets.AWS_GITHUB_ACTIONS_OIDC_ROLE_ARN }}
-          role-chaining: true
 
       - name: Create Terraform Plugin Cache Dir
         run: mkdir -p ${{ env.TF_PLUGIN_CACHE_DIR }}

--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -47,7 +47,6 @@ jobs:
         with:
           aws-region: ${{ env.aws_default_region }}
           role-to-assume: ${{ secrets.AWS_GITHUB_ACTIONS_OIDC_ROLE_ARN }}
-          role-chaining: true
 
       - name: Create Terraform Plugin Cache Dir
         run: mkdir -p ${{ env.TF_PLUGIN_CACHE_DIR }}


### PR DESCRIPTION
## Summary
- remove `role-chaining` setting from terragrunt workflows

## Testing
- `tflint --version` *(fails: command not found)*
- `terraform version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685cec73f7ac8324b81f1371f958ba5c