### PR TITLE
Fix plugin cache key

### DIFF
--- a/.github/workflows/terragrunt-apply.yml
+++ b/.github/workflows/terragrunt-apply.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.TF_PLUGIN_CACHE_DIR }}
-          key: ${{ runner.os }}-terraform-plugin-cache-${{ hashFiles('**/.terraform.lock.hcl') }}
+          key: ${{ runner.os }}-terraform-plugin-cache-${{ hashFiles('**/*.tf') }}
 
       - name: Terragrunt apply
         uses: gruntwork-io/terragrunt-action@v2

--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.TF_PLUGIN_CACHE_DIR }}
-          key: ${{ runner.os }}-terraform-plugin-cache-${{ hashFiles('**/.terraform.lock.hcl') }}
+          key: ${{ runner.os }}-terraform-plugin-cache-${{ hashFiles('**/*.tf') }}
 
       - name: Terragrunt plan
         id: tg_plan


### PR DESCRIPTION
## Summary
- stop using `.terraform.lock.hcl` for the plugin cache

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_685ceeba9fb88324bd1881e3a43ddb1c