### PR TITLE
Fix Terragrunt module source paths

### DIFF
--- a/infra/terragrunt/environment/dev/aws/terragrunt.hcl
+++ b/infra/terragrunt/environment/dev/aws/terragrunt.hcl
@@ -3,7 +3,10 @@ include {
 }
 
 terraform {
-  source = "../../../module/aws"
+  # Include the entire module directory so that submodules referenced using
+  # relative paths are available during Terraform execution. The `//aws`
+  # suffix selects the `aws` subdirectory as the entry point.
+  source = "../../../module//aws"
 }
 
 dependencies {

--- a/infra/terragrunt/environment/dev/backend/terragrunt.hcl
+++ b/infra/terragrunt/environment/dev/backend/terragrunt.hcl
@@ -3,7 +3,10 @@ include {
 }
 
 terraform {
-  source = "../../../module/backend"
+  # Copy the full module tree so Terraform has access to all nested modules.
+  # The `//backend` suffix ensures the backend module is used as the entry
+  # point while the rest of the directory is preserved in the cache.
+  source = "../../../module//backend"
 }
 
 dependencies {

--- a/infra/terragrunt/environment/dev/cicd/terragrunt.hcl
+++ b/infra/terragrunt/environment/dev/cicd/terragrunt.hcl
@@ -3,7 +3,11 @@ include {
 }
 
 terraform {
-  source = "../../../module/cicd"
+  # Copy the entire module directory so that nested modules referenced by
+  # relative paths are available during execution. Using the `//cicd` suffix
+  # instructs Terragrunt/Terraform to run the `cicd` subdirectory while
+  # including the rest of the module files in the cache.
+  source = "../../../module//cicd"
 }
 
 locals {


### PR DESCRIPTION
## Summary
- ensure full module tree is copied when running Terragrunt

## Testing
- `bash scripts/local_tflint.sh` *(fails: `/mnt/c/project/openmetadata-assets/infra/terragrunt/module` no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_685cf816955c8324b6667076097c45fc