### PR TITLE
Add terragrunt hooks for fmt/validate

### DIFF
--- a/infra/terragrunt/root.hcl
+++ b/infra/terragrunt/root.hcl
@@ -41,3 +41,15 @@ provider "http" {}
 provider "random" {}
 EOT
 }
+
+terraform {
+  before_hook "fmt" {
+    commands = ["plan", "apply"]
+    execute  = ["terraform", "fmt", "-check", "-recursive"]
+  }
+
+  before_hook "validate" {
+    commands = ["plan", "apply"]
+    execute  = ["terraform", "validate"]
+  }
+}


### PR DESCRIPTION
## Summary
- run `terraform fmt` and `terraform validate` automatically before `plan` and `apply`

## Testing
- `terraform fmt -check -recursive infra/terragrunt`
- `terraform init -backend=false -input=false` and `terraform validate` for modules

------
https://chatgpt.com/codex/tasks/task_b_685cf9738f7c8324b370680c3da280c8