### PR TITLE
Update dev CIDR values

### DIFF
--- a/infra/terragrunt/environment/dev/aws/terragrunt.hcl
+++ b/infra/terragrunt/environment/dev/aws/terragrunt.hcl
@@ -22,9 +22,9 @@ locals {
 
   allowed_ip_list = ["" ]
 
-  cidr_vpc             = ""
-  cidr_subnets_public  = ["", ""]
-  cidr_subnets_private = ["", ""]
+  cidr_vpc             = "10.0.0.0/16"
+  cidr_subnets_public  = ["10.0.0.0/24", "10.0.1.0/24"]
+  cidr_subnets_private = ["10.0.10.0/24", "10.0.11.0/24"]
   az_a_name            = "ap-northeast-1a"
   az_c_name            = "ap-northeast-1c"
 


### PR DESCRIPTION
## Summary
- define CIDR ranges for the dev environment using the 10.0 network

## Testing
- `terraform fmt -check -recursive infra/terragrunt`
- `terragrunt init -backend=false` *(fails: Missing AWS credentials)*

------
https://chatgpt.com/codex/tasks/task_b_685cfff20c808324b6db7378230d40ad