### PR TITLE
Update agent instructions for Terragrunt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,4 +2,5 @@
 
 - Follow the Terragrunt best practices described in [Terragrunt Infrastructure Catalog Example](https://github.com/gruntwork-io/terragrunt-infrastructure-catalog-example).
 - Always use the latest stable versions of Terraform and Terragrunt for this repository. Update version constraints in `root.hcl`, GitHub Actions workflows, and any other configuration files accordingly.
+- Install Terragrunt from the official releases at [gruntwork-io/terragrunt](https://github.com/gruntwork-io/terragrunt). Always use the most recent release binary for your platform.
 


### PR DESCRIPTION
## Summary
- add guidance to install Terragrunt from the latest GitHub release

## Testing
- `terraform fmt -check -recursive` *(fails: command not found)*
- `tflint --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685e3173934083249bb466598b644f09