### PR TITLE
Fix terragrunt plan log

### DIFF
--- a/.github/workflows/terragrunt-apply.yml
+++ b/.github/workflows/terragrunt-apply.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   aws_default_region: ap-northeast-1
-  tg_version: 0.82.0
+  tg_version: 0.82.2
   tf_version: 1.12.2
   deploy_env: ${{ github.event.inputs.environment || 'dev' }}
   TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache

--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -18,7 +18,7 @@ on:
 
 env:
   aws_default_region: ap-northeast-1
-  tg_version: 0.82.0
+  tg_version: 0.82.2
   tf_version: 1.12.2
   deploy_env: ${{ github.event.inputs.environment || 'dev' }}
   TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
@@ -71,7 +71,8 @@ jobs:
           tg_add_approve: 0
 
       - name: Save plan log
-        run: echo "${{ steps.tg_plan.outputs.tg_action_output }}" > terragrunt-plan.log
+        run: |
+          printf '%s' "${{ steps.tg_plan.outputs.tg_action_output }}" > terragrunt-plan.log
 
       - name: Comment plan result on PR
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
- use latest Terragrunt 0.82.2 release
- protect plan log saving with printf so logs containing quotes won't break

## Testing
- `terraform fmt -check -recursive`

------
https://chatgpt.com/codex/tasks/task_b_685e394cb9c08324967861501c3f6491