### PR TITLE
Fix Terraform plugin cache key to also hash hcl files

### DIFF
--- a/.github/workflows/terragrunt-apply.yml
+++ b/.github/workflows/terragrunt-apply.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.TF_PLUGIN_CACHE_DIR }}
-          key: ${{ runner.os }}-terraform-plugin-cache-${{ hashFiles('**/*.tf') }}
+          key: ${{ runner.os }}-terraform-plugin-cache-${{ hashFiles('**/*.tf', '**/*.hcl') }}
 
       - name: Terragrunt apply
         uses: gruntwork-io/terragrunt-action@v2

--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.TF_PLUGIN_CACHE_DIR }}
-          key: ${{ runner.os }}-terraform-plugin-cache-${{ hashFiles('**/*.tf') }}
+          key: ${{ runner.os }}-terraform-plugin-cache-${{ hashFiles('**/*.tf', '**/*.hcl') }}
 
       - name: Terragrunt plan
         id: tg_plan


### PR DESCRIPTION
## Summary
- include `.hcl` files when hashing for the Terraform plugin cache

## Testing
- `terraform -version` *(fails: command not found)*
- `terragrunt --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685e3c2e8f80832480da2d2927c00961