### PR TITLE
Run plan only on terraform change

### DIFF
--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ "main" ]
     types: [opened, synchronize, reopened]
+    paths:
+      - '**/*.tf'
+      - '**/*.hcl'
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
## Summary
- limit terragrunt plan workflow to run only when HCL or TF files are modified

## Testing
- `tflint --version` *(fails: command not found)*
- `terraform -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685e43a5ee2c832489dd493ce0e53746