### PR TITLE
Decode terragrunt output in plan workflow

### DIFF
--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -77,9 +77,8 @@ jobs:
       - name: Save plan log
         if: always()
         run: |
-          cat <<'EOF' > terragrunt-plan.log
-          ${{ steps.tg_plan.outputs.tg_action_output }}
-          EOF
+          # %0A を実改行に変換して保存
+          printf '%b' "${{ steps.tg_plan.outputs.tg_action_output//%0A/\\n}}" > terragrunt-plan.log
 
       # ──────────────── Upload artifact ────────────────
       - name: Upload plan log artifact
@@ -89,24 +88,26 @@ jobs:
         with:
           name: terragrunt-plan-${{ env.deploy_env }}-${{ github.sha }}
           path: terragrunt-plan.log
-          retention-days: 365
+          retention-days: 14
 
       # ──────────────── Build PR comment body ────────────────
       - name: Build PR comment body
         if: always()
+        shell: bash
         run: |
-          cat <<'EOF' > pr-comment.md
-          ### :seedling: Terragrunt Plan (env: **${{ env.deploy_env }}**)
-          **Status**: ${{ steps.tg_plan.outcome }}
-          **Log**: [📦 terragrunt-plan log](${{ steps.upload_plan_log.outputs.artifact-url }})
-
-          <details><summary>Show plan output</summary>
-
-          ```terraform
-          ${{ steps.tg_plan.outputs.tg_action_output }}
-          ```
-          </details>
-          EOF
+          PLAN_DECODED=$(printf '%b' "${{ steps.tg_plan.outputs.tg_action_output//%0A/\\n}}")
+          {
+            echo "### :seedling: Terragrunt Plan (env: **${{ env.deploy_env }}**)"
+            echo "**Status**: ${{ steps.tg_plan.outcome }}"
+            echo "**Log**: [📦 terragrunt-plan log](${{ steps.upload_plan_log.outputs.artifact-url }})"
+            echo
+            echo "<details><summary>Show plan output</summary>"
+            echo
+            echo '```terraform'
+            echo "$PLAN_DECODED"
+            echo '```'
+            echo "</details>"
+          } > pr-comment.md
 
       # ──────────────── Comment on PR ────────────────
       - name: Comment plan result on PR


### PR DESCRIPTION
## Summary
- decode plan output so newlines display correctly
- reduce plan log retention to two weeks

## Testing
- `tflint --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685e45a87e0483248934944ee138045d