### PR TITLE
Add tfsec action workflow

### DIFF
--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -1,0 +1,35 @@
+name: tfsec
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+env:
+  tfsec_version: v1.28.14
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tfsec:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      name: Checkout source code
+
+    - name: tfsec
+      uses: aquasecurity/tfsec-action@f2f46914fe6c55dadcb05e28190283b9bdc906c7 # v1.0.3
+      with:
+        version: ${{ env.tfsec_version }}
+        working_directory: infra/terragrunt/modules
+        additional_args: --force-all-dirs
+

--- a/infra/terragrunt/modules/aws/network/sg.tf
+++ b/infra/terragrunt/modules/aws/network/sg.tf
@@ -23,7 +23,7 @@ resource "aws_security_group" "self_reference" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [var.cidr_vpc]
   }
 
   tags = {


### PR DESCRIPTION
## Summary
- replace manual tfsec install with tfsec-action workflow
- scope scan to modules directory and force scanning all subdirs
- limit network security group egress to the VPC CIDR

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6877fc692ae48324b8b1005e4d6a5a72